### PR TITLE
Call load() in BuildStepDescriptor

### DIFF
--- a/src/main/java/jenkins/plugins/hipchat/HipChatNotifier.java
+++ b/src/main/java/jenkins/plugins/hipchat/HipChatNotifier.java
@@ -88,6 +88,10 @@ public class HipChatNotifier extends Notifier {
       private String room;
       private String jenkinsUrl;
 
+      public DescriptorImpl() {
+         load();
+      }	
+
       public String getToken() {
          return token;
       }


### PR DESCRIPTION
load() wasn't being called in the build step descriptor so global configuration parameters was being persisted but never read after restart.

As you can see I've added a default constructor with a call to load(), though I'm not familiar with jenkins plugin best-practices and suspect there's a better way to do it.

Thanks!
