### PR TITLE
HipChatNotifier appropriately uses class variables

### DIFF
--- a/src/main/java/jenkins/plugins/hipchat/HipChatNotifier.java
+++ b/src/main/java/jenkins/plugins/hipchat/HipChatNotifier.java
@@ -32,19 +32,19 @@ public class HipChatNotifier extends Notifier {
     }
 
     public String getRoom() {
-        return room;
+        return this.room;
     }
 
     public String getAuthToken() {
-        return authToken;
+        return this.authToken;
     }
 
     public String getBuildServerUrl() {
-        return buildServerUrl;
+        return this.buildServerUrl;
     }
 
     public String getSendAs() {
-        return sendAs;
+        return this.sendAs;
     }
 
     public void setBuildServerUrl(final String buildServerUrl) {

--- a/src/main/resources/jenkins/plugins/hipchat/HipChatNotifier/HipChatJobProperty/config.jelly
+++ b/src/main/resources/jenkins/plugins/hipchat/HipChatNotifier/HipChatJobProperty/config.jelly
@@ -1,13 +1,13 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 
-	<f:section title="HipChat Notifications">
-    	<f:entry title="Project Room">
-      		<f:textbox name="hipChatProjectRoom" value="${instance.getRoom()}"/>
-    	</f:entry>
+    <f:section title="HipChat Notifications">
+        <f:entry title="Project Room">
+            <f:textbox name="hipChatProjectRoom" value="${instance.getRoom()}"/>
+        </f:entry>
 
-    	<f:entry title="Notify Build Start">
-      		<f:checkbox name="hipChatStartNotification" value="true" checked="${instance.getStartNotification()}"/>
-    	</f:entry>
+        <f:entry title="Notify Build Start">
+            <f:checkbox name="hipChatStartNotification" value="true" checked="${instance.getStartNotification()}"/>
+        </f:entry>
 
         <f:entry title="Notify Aborted">
             <f:checkbox name="hipChatNotifyAborted" value="true" checked="${instance.getNotifyAborted()}"/>


### PR DESCRIPTION
Urls posted to hipchat client were wrong before. This fixes the issue by loading the correct URL from the HipChatNotifier class variable.
Url was:
file:///Applications/HipChat.app/Contents/Resources/nulljob/TEST_HIPCHAT/5/

Url should have been:
http://172.24.46.2:8080/job/TEST_HIPCHAT/5/

Also fixed spaces/tabs.
