### PR TITLE
Fixed bug that caused the build to fail for some SCMs

### DIFF
--- a/src/main/java/jenkins/plugins/hipchat/ActiveNotifier.java
+++ b/src/main/java/jenkins/plugins/hipchat/ActiveNotifier.java
@@ -84,7 +84,12 @@ public class ActiveNotifier implements FineGrainedNotifier {
             Entry entry = (Entry) o;
             logger.info("Entry " + o);
             entries.add(entry);
-            files.addAll(entry.getAffectedFiles());
+            try{
+            	files.addAll(entry.getAffectedFiles());
+            } catch (UnsupportedOperationException e) {
+            	logger.info(e.getMessage());
+            	return null;
+            }
         }
         if (entries.isEmpty()) {
             logger.info("Empty change...");


### PR DESCRIPTION
When using the getAffectedFiles method it can return an exception if the SCM does not implement it. This happened with TFS. I added a try catch to handle this exception. It will return null if the SCM cannot get the files but it will continue with the build. 
