### PR TITLE
Add an option to support using the v2 hipchat API.

### DIFF
--- a/src/main/java/jenkins/plugins/hipchat/HipChatNotifier.java
+++ b/src/main/java/jenkins/plugins/hipchat/HipChatNotifier.java
@@ -22,6 +22,7 @@ public class HipChatNotifier extends Notifier {
 
     private static final Logger logger = Logger.getLogger(HipChatNotifier.class.getName());
 
+    private Boolean v2API;
     private String server;
     private String authToken;
     private String buildServerUrl;
@@ -53,15 +54,19 @@ public class HipChatNotifier extends Notifier {
         return this.sendAs;
     }
 
+    public Boolean isV2API() {
+        return v2API;
+    }
 
     @DataBoundConstructor
-    public HipChatNotifier(final String server, final String authToken, final String room, String buildServerUrl, final String sendAs) {
+    public HipChatNotifier(final String server, final String authToken, final String room, String buildServerUrl, final String sendAs, final boolean v2API) {
         super();
         this.server = server;
         this.authToken = authToken;
         this.buildServerUrl = buildServerUrl;
         this.room = room;
         this.sendAs = sendAs;
+        this.v2API = v2API;
     }
 
     public BuildStepMonitor getRequiredMonitorService() {
@@ -69,7 +74,7 @@ public class HipChatNotifier extends Notifier {
     }
 
     public HipChatService newHipChatService(final String room) {
-        return new StandardHipChatService(getServer(), getAuthToken(), room == null ? getRoom() : room, StringUtils.isBlank(getSendAs()) ? "Build Server" : getSendAs());
+        return new StandardHipChatService(getServer(), getAuthToken(), room == null ? getRoom() : room, StringUtils.isBlank(getSendAs()) ? "Build Server" : getSendAs(), isV2API());
     }
 
     @Override
@@ -84,6 +89,7 @@ public class HipChatNotifier extends Notifier {
         private String room;
         private String buildServerUrl;
         private String sendAs;
+        private Boolean v2API;
 
         public DescriptorImpl() {
             load();
@@ -109,6 +115,10 @@ public class HipChatNotifier extends Notifier {
             return sendAs;
         }
 
+        public Boolean getV2API() {
+            return v2API;
+        }
+
         public boolean isApplicable(Class<? extends AbstractProject> aClass) {
             return true;
         }
@@ -120,7 +130,8 @@ public class HipChatNotifier extends Notifier {
             if (buildServerUrl == null) buildServerUrl = sr.getParameter("hipChatBuildServerUrl");
             if (room == null) room = sr.getParameter("hipChatRoom");
             if (sendAs == null) sendAs = sr.getParameter("hipChatSendAs");
-            return new HipChatNotifier(server, token, room, buildServerUrl, sendAs);
+            if (v2API == null) v2API = Boolean.valueOf(sr.getParameter("hipChatAPIV2")).booleanValue();
+            return new HipChatNotifier(server, token, room, buildServerUrl, sendAs, v2API);
         }
 
         @Override
@@ -130,11 +141,12 @@ public class HipChatNotifier extends Notifier {
             room = sr.getParameter("hipChatRoom");
             buildServerUrl = sr.getParameter("hipChatBuildServerUrl");
             sendAs = sr.getParameter("hipChatSendAs");
+            v2API = Boolean.valueOf(sr.getParameter("hipChatAPIV2"));
             if (buildServerUrl != null && !buildServerUrl.endsWith("/")) {
                 buildServerUrl = buildServerUrl + "/";
             }
             try {
-                new HipChatNotifier(server, token, room, buildServerUrl, sendAs);
+                new HipChatNotifier(server, token, room, buildServerUrl, sendAs, v2API);
             } catch (Exception e) {
                 throw new FormException("Failed to initialize notifier - check your global notifier configuration settings", e, "");
             }

--- a/src/main/java/jenkins/plugins/hipchat/StandardHipChatService.java
+++ b/src/main/java/jenkins/plugins/hipchat/StandardHipChatService.java
@@ -2,11 +2,13 @@ package jenkins.plugins.hipchat;
 
 import hudson.ProxyConfiguration;
 import jenkins.model.Jenkins;
+import net.sf.json.JSONObject;
 import org.apache.commons.httpclient.HttpClient;
 import org.apache.commons.httpclient.HttpStatus;
 import org.apache.commons.httpclient.methods.PostMethod;
+import org.apache.commons.httpclient.methods.StringRequestEntity;
 
-import java.util.List;
+import java.io.UnsupportedEncodingException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -20,13 +22,15 @@ public class StandardHipChatService implements HipChatService {
     private String token;
     private String[] roomIds;
     private String from;
+    private Boolean v2API;
 
-    public StandardHipChatService(String host, String token, String roomIds, String from) {
+    public StandardHipChatService(String host, String token, String roomIds, String from, Boolean v2API) {
         super();
         this.host = host == null ? DEFAULT_HOST : host;
         this.token = token;
         this.roomIds = roomIds == null ? DEFAULT_ROOMS : roomIds.split("\\s*,\\s*");
         this.from = from == null ? DEFAULT_FROM : from;
+        this.v2API = v2API == null ? false : v2API;
     }
 
     public void publish(String message) {
@@ -37,27 +41,55 @@ public class StandardHipChatService implements HipChatService {
         for (String roomId : roomIds) {
             logger.info("Posting: " + from + " to " + roomId + ": " + message + " " + color);
             HttpClient client = getHttpClient();
-            String url = "https://" + host + "/v1/rooms/message?auth_token=" + token;
-            PostMethod post = new PostMethod(url);
 
+            PostMethod post = null;
             try {
-                post.addParameter("from", from);
-                post.addParameter("room_id", roomId);
-                post.addParameter("message", message);
-                post.addParameter("color", color);
-                post.addParameter("notify", shouldNotify(color));
-                post.getParams().setContentCharset("UTF-8");
+                if (v2API) {
+                    post = buildV2Notification(message, color, roomId);
+                } else {
+                    post = buildV1Notification(message, color, roomId);
+                }
                 int responseCode = client.executeMethod(post);
                 String response = post.getResponseBodyAsString();
-                if (responseCode != HttpStatus.SC_OK || !response.contains("\"sent\"")) {
-                    logger.log(Level.WARNING, "HipChat post may have failed. Response: " + response);
+                if (!v2API && (responseCode != HttpStatus.SC_OK || !response.contains("\"sent\""))
+                        || (v2API && responseCode != HttpStatus.SC_NO_CONTENT)) {
+                    logger.log(Level.WARNING, "HipChat post may have failed. Response Code: " + responseCode + ". Response: " + response);
                 }
             } catch (Exception e) {
                 logger.log(Level.WARNING, "Error posting to HipChat", e);
             } finally {
-                post.releaseConnection();
+                if (post != null) {
+                    post.releaseConnection();
+                }
             }
         }
+    }
+
+    private PostMethod buildV1Notification(String message, String color, String roomId) {
+        String url = "https://" + host + "/v1/rooms/message?auth_token=" + token;
+        PostMethod post = new PostMethod(url);
+        post.addParameter("from", from);
+        post.addParameter("room_id", roomId);
+        post.addParameter("message", message);
+        post.addParameter("color", color);
+        post.addParameter("notify", shouldNotifyAsString(color));
+        post.getParams().setContentCharset("UTF-8");
+        return post;
+    }
+
+    private PostMethod buildV2Notification(String message, String color, String roomId)
+            throws UnsupportedEncodingException {
+        String url = "https://" + host + "/v2/room/" + roomId + "/notification?auth_token=" + token;
+
+        JSONObject postJSON = new JSONObject();
+        postJSON.put("message", message);
+        postJSON.put("color", color);
+        postJSON.put("notify", shouldNotify(color));
+
+        StringRequestEntity requestEntity = new StringRequestEntity(postJSON.toString(), "application/json", "UTF-8");
+        PostMethod post = new PostMethod(url);
+        post.setRequestEntity(requestEntity);
+        return post;
     }
 
     private HttpClient getHttpClient() {
@@ -74,8 +106,12 @@ public class StandardHipChatService implements HipChatService {
         return client;
     }
 
-    private String shouldNotify(String color) {
+    private String shouldNotifyAsString(String color) {
         return color.equalsIgnoreCase("green") ? "0" : "1";
+    }
+
+    private Boolean shouldNotify(String color) {
+        return color.equalsIgnoreCase("green");
     }
 
     public String getHost() {
@@ -88,5 +124,9 @@ public class StandardHipChatService implements HipChatService {
 
     public String getFrom() {
         return from;
+    }
+
+    public Boolean isV2API() {
+        return v2API;
     }
 }

--- a/src/main/resources/jenkins/plugins/hipchat/HipChatNotifier/global.jelly
+++ b/src/main/resources/jenkins/plugins/hipchat/HipChatNotifier/global.jelly
@@ -17,6 +17,7 @@
     </f:entry>
     <f:entry title="API Token" help="${rootURL}/plugin/hipchat/help-globalConfig-hipChatToken.html">
         <f:textbox name="hipChatToken" value="${descriptor.getToken()}" />
+        <f:checkbox name="hipChatAPIV2" title="API Token uses v2 of the hipchat API" value="true" checked="${descriptor.isV2API()}" />
     </f:entry>
     <f:entry title="Room" help="${rootURL}/plugin/hipchat/help-globalConfig-hipChatRoom.html">
         <f:textbox name="hipChatRoom" value="${descriptor.getRoom()}" />

--- a/src/main/webapp/help-globalConfig-hipChatSendAs.html
+++ b/src/main/webapp/help-globalConfig-hipChatSendAs.html
@@ -1,4 +1,6 @@
 <div xmlns="http://www.w3.org/1999/html">
 	<p>Optionally specify a name to send the notifications as.</p>
     <p>If not specified, messages will be sent as "Build Server".</p>
+    <p>Note that this only works if you're using v1 of the HipChat API.</p>
+    <p>The sendAs name for v2 APIs is defined server side for each API token.</p>
 </div>

--- a/src/main/webapp/help-globalConfig-hipChatToken.html
+++ b/src/main/webapp/help-globalConfig-hipChatToken.html
@@ -1,3 +1,4 @@
 <div>
 	<p>The API authentication token to be used to send notifications to HipChat. You can copy this from the settings page within HipChat.</p>
+    <p>The v2 API has a different structure so make sure to enable the v2 checkbox if your API token is a v2 Hipchat API Token.</p>
 </div>

--- a/src/test/java/jenkins/plugins/hipchat/StandardHipChatServiceTest.java
+++ b/src/test/java/jenkins/plugins/hipchat/StandardHipChatServiceTest.java
@@ -3,54 +3,68 @@ package jenkins.plugins.hipchat;
 import org.junit.Test;
 
 import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertTrue;
+import static junit.framework.Assert.assertFalse;
 import static org.junit.Assert.assertArrayEquals;
 
 public class StandardHipChatServiceTest {
     @Test
     public void publishWithBadHostShouldNotRethrowExceptions() {
-        StandardHipChatService service = new StandardHipChatService("badhost", "token", "room", "from");
+        StandardHipChatService service = new StandardHipChatService("badhost", "token", "room", "from", false);
         service.publish("message");
     }
 
     @Test
     public void shouldSetADefaultHost() {
-        StandardHipChatService service = new StandardHipChatService(null, "token", "room", "from");
+        StandardHipChatService service = new StandardHipChatService(null, "token", "room", "from", false);
         assertEquals("api.hipchat.com", service.getHost());
     }
 
     @Test
     public void shouldBeAbleToOverrideHost() {
-        StandardHipChatService service = new StandardHipChatService("some.other.host", "token", "room", "from");
+        StandardHipChatService service = new StandardHipChatService("some.other.host", "token", "room", "from", false);
         assertEquals("some.other.host", service.getHost());
     }
 
     @Test
     public void shouldSplitTheRoomIds() {
-        StandardHipChatService service = new StandardHipChatService(null, "token", "room1,room2", "from");
+        StandardHipChatService service = new StandardHipChatService(null, "token", "room1,room2", "from", false);
         assertArrayEquals(new String[]{"room1", "room2"}, service.getRoomIds());
     }
 
     @Test
     public void shouldTrimTheRoomIds() {
-        StandardHipChatService service = new StandardHipChatService(null, "token", "room1, room2", "from");
+        StandardHipChatService service = new StandardHipChatService(null, "token", "room1, room2", "from", false);
         assertArrayEquals(new String[]{"room1", "room2"}, service.getRoomIds());
     }
 
     @Test
     public void shouldNotSplitTheRoomsIfNullIsPassed() {
-        StandardHipChatService service = new StandardHipChatService(null, "token", null, "from");
+        StandardHipChatService service = new StandardHipChatService(null, "token", null, "from", false);
         assertArrayEquals(new String[0], service.getRoomIds());
     }
 
     @Test
     public void shouldProvideADefaultFrom() {
-        StandardHipChatService service = new StandardHipChatService(null, "token", "room", null);
+        StandardHipChatService service = new StandardHipChatService(null, "token", "room", null, false);
         assertEquals("Build Server", service.getFrom());
     }
 
     @Test
     public void shouldBeAbleToOverrideFrom() {
-        StandardHipChatService service = new StandardHipChatService(null, "token", "room", "from");
+        StandardHipChatService service = new StandardHipChatService(null, "token", "room", "from", false);
         assertEquals("from", service.getFrom());
+    }
+
+    @Test
+    public void shouldOverrideAPIToVersion2() {
+        StandardHipChatService service = new StandardHipChatService(null, "token", "room", "from", true);
+        assertTrue(service.isV2API());
+    }
+
+    @Test
+    public void shouldAPIDefaultToVersion1() {
+        StandardHipChatService service = new StandardHipChatService(null, "token", "room", "from", false);
+        assertFalse(service.isV2API());
     }
 }


### PR DESCRIPTION
Add an option to support using the v2 hipchat API.
Right now it's just one auth token globally, but in the future we should allow adding multiple tokens to more easily support multiple rooms.