### PR TITLE
Correctly notify jenkins about success of notification

### DIFF
--- a/src/main/java/jenkins/plugins/hipchat/HipChatNotifier.java
+++ b/src/main/java/jenkins/plugins/hipchat/HipChatNotifier.java
@@ -159,7 +159,7 @@ public class HipChatNotifier extends Notifier {
             throws InterruptedException, IOException {
         logger.info("Invoking Completed...");
         new ActiveNotifier(this).completed(build);
-        return super.perform(build, launcher, listener);
+        return true;
     }
 
     @Extension


### PR DESCRIPTION
use correct path when referencing help files 

closes jlewallen/jenkins-hipchat-plugin#75