### PR TITLE
Allow to customize the message that gets printed in the chat room

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,8 +57,28 @@
             <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
-                <version>4.12</version>
+                <version>4.11</version>
                 <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-core</artifactId>
+                <version>1.9.5</version>
+            </dependency>
+            <dependency>
+                <groupId>org.powermock</groupId>
+                <artifactId>powermock-module-junit4</artifactId>
+                <version>1.5.6</version>
+            </dependency>
+            <dependency>
+                <groupId>org.powermock</groupId>
+                <artifactId>powermock-api-mockito</artifactId>
+                <version>1.5.6</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hamcrest</groupId>
+                <artifactId>hamcrest-all</artifactId>
+                <version>1.3</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -71,17 +91,37 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-junit4</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-mockito</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
         <pluginManagement>
             <plugins>
                 <plugin>
-                   <groupId>org.jenkins-ci.tools</groupId>
-                   <artifactId>maven-hpi-plugin</artifactId>
-                   <configuration>
-                       <disabledTestInjection>true</disabledTestInjection>
-                   </configuration>
+                    <groupId>org.jenkins-ci.tools</groupId>
+                    <artifactId>maven-hpi-plugin</artifactId>
+                    <configuration>
+                        <disabledTestInjection>true</disabledTestInjection>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <artifactId>maven-release-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -138,6 +138,15 @@
                 </plugin>
             </plugins>
         </pluginManagement>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.6</source>
+                    <target>1.6</target>
+                </configuration>
+            </plugin>
+        </plugins>
     </build>
 
     <repositories>

--- a/src/main/java/jenkins/plugins/hipchat/HipChatNotifier.java
+++ b/src/main/java/jenkins/plugins/hipchat/HipChatNotifier.java
@@ -1,6 +1,5 @@
 package jenkins.plugins.hipchat;
 
-import com.google.common.base.Preconditions;
 import hudson.Extension;
 import hudson.Launcher;
 import hudson.Util;
@@ -15,8 +14,6 @@ import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Notifier;
 import hudson.tasks.Publisher;
 import hudson.util.FormValidation;
-import java.io.IOException;
-import java.util.logging.Logger;
 import jenkins.model.Jenkins;
 import jenkins.plugins.hipchat.impl.HipChatV1Service;
 import jenkins.plugins.hipchat.impl.HipChatV2Service;
@@ -27,7 +24,10 @@ import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.export.Exported;
 
-import static jenkins.plugins.hipchat.NotificationType.*;
+import java.io.IOException;
+import java.util.logging.Logger;
+
+import static jenkins.plugins.hipchat.NotificationType.STARTED;
 
 @SuppressWarnings({"unchecked"})
 public class HipChatNotifier extends Notifier {
@@ -43,20 +43,14 @@ public class HipChatNotifier extends Notifier {
     private boolean notifyFailure;
     private boolean notifyBackToNormal;
 
-    private String messageStarted;
-    private String messageBackToNormal;
-    private String messageSuccess;
-    private String messageFailure;
-    private String messageAborted;
-    private String messageNotBuilt;
-    private String messageUnstable;
+    private String startJobMessage;
+    private String completeJobMessage;
 
     @DataBoundConstructor
     public HipChatNotifier(String token, String room, boolean startNotification, boolean notifySuccess,
             boolean notifyAborted, boolean notifyNotBuilt, boolean notifyUnstable, boolean notifyFailure,
             boolean notifyBackToNormal,
-            String messageStarted, String messageBackToNormal, String messageSuccess, String messageFailure,
-            String messageAborted, String messageNotBuilt, String messageUnstable) {
+            String startJobMessage, String completeJobMessage) {
         this.token = token;
         this.room = room;
         this.startNotification = startNotification;
@@ -66,13 +60,9 @@ public class HipChatNotifier extends Notifier {
         this.notifyUnstable = notifyUnstable;
         this.notifyFailure = notifyFailure;
         this.notifyBackToNormal = notifyBackToNormal;
-        this.messageStarted = messageStarted;
-        this.messageBackToNormal = messageBackToNormal;
-        this.messageSuccess = messageSuccess;
-        this.messageFailure = messageFailure;
-        this.messageAborted = messageAborted;
-        this.messageNotBuilt = messageNotBuilt;
-        this.messageUnstable = messageUnstable;
+
+        this.startJobMessage = startJobMessage;
+        this.completeJobMessage = completeJobMessage;
     }
 
     /* notification enabled disabled setter/getter */
@@ -135,66 +125,28 @@ public class HipChatNotifier extends Notifier {
 
     /* notification message configuration*/
 
-    public String getMessageStarted() {
-        return messageStarted;
+    public String getCompleteJobMessage() {
+        return completeJobMessage;
     }
 
-    public void setMessageStarted(String messageStarted) {
-        this.messageStarted = messageStarted;
+    public void setCompleteJobMessage(String completeJobMessage) {
+        this.completeJobMessage = completeJobMessage;
     }
 
-    public String getMessageBackToNormal() {
-        return messageBackToNormal;
+    public String getStartJobMessage() {
+        return startJobMessage;
     }
 
-    public void setMessageBackToNormal(String messageBackToNormal) {
-        this.messageBackToNormal = messageBackToNormal;
+    public void setStartJobMessage(String startJobMessage) {
+        this.startJobMessage = startJobMessage;
     }
 
-    public String getMessageSuccess() {
-        return messageSuccess;
+    public String getCompleteJobMessageDefault() {
+        return Messages.JobCompleted();
     }
 
-    public void setMessageSuccess(String messageSuccess) {
-        this.messageSuccess = messageSuccess;
-    }
-
-    public String getMessageFailure() {
-        return messageFailure;
-    }
-
-    public void setMessageFailure(String messageFailure) {
-        this.messageFailure = messageFailure;
-    }
-
-    public String getMessageAborted() {
-        return messageAborted;
-    }
-
-    public void setMessageAborted(String messageAborted) {
-        this.messageAborted = messageAborted;
-    }
-
-    public String getMessageNotBuilt() {
-        return messageNotBuilt;
-    }
-
-    public void setMessageNotBuilt(String messageNotBuilt) {
-        this.messageNotBuilt = messageNotBuilt;
-    }
-
-    public String getMessageUnstable() {
-        return messageUnstable;
-    }
-
-    public void setMessageUnstable(String messageUnstable) {
-        this.messageUnstable = messageUnstable;
-    }
-
-    public String getMessageDefault(String enumName) {
-        NotificationType type = NotificationType.valueOf(enumName);
-        Preconditions.checkNotNull(type, "unknown NotificationType %s", enumName);
-        return type.getDefaultTemplate();
+    public String getStartJobMessageDefault() {
+        return Messages.JobStarted();
     }
 
     public String getRoom() {

--- a/src/main/java/jenkins/plugins/hipchat/HipChatNotifier.java
+++ b/src/main/java/jenkins/plugins/hipchat/HipChatNotifier.java
@@ -1,5 +1,6 @@
 package jenkins.plugins.hipchat;
 
+import com.google.common.base.Preconditions;
 import hudson.Extension;
 import hudson.Launcher;
 import hudson.Util;
@@ -42,10 +43,20 @@ public class HipChatNotifier extends Notifier {
     private boolean notifyFailure;
     private boolean notifyBackToNormal;
 
+    private String messageStarted;
+    private String messageBackToNormal;
+    private String messageSuccess;
+    private String messageFailure;
+    private String messageAborted;
+    private String messageNotBuilt;
+    private String messageUnstable;
+
     @DataBoundConstructor
     public HipChatNotifier(String token, String room, boolean startNotification, boolean notifySuccess,
             boolean notifyAborted, boolean notifyNotBuilt, boolean notifyUnstable, boolean notifyFailure,
-            boolean notifyBackToNormal) {
+            boolean notifyBackToNormal,
+            String messageStarted, String messageBackToNormal, String messageSuccess, String messageFailure,
+            String messageAborted, String messageNotBuilt, String messageUnstable) {
         this.token = token;
         this.room = room;
         this.startNotification = startNotification;
@@ -55,7 +66,16 @@ public class HipChatNotifier extends Notifier {
         this.notifyUnstable = notifyUnstable;
         this.notifyFailure = notifyFailure;
         this.notifyBackToNormal = notifyBackToNormal;
+        this.messageStarted = messageStarted;
+        this.messageBackToNormal = messageBackToNormal;
+        this.messageSuccess = messageSuccess;
+        this.messageFailure = messageFailure;
+        this.messageAborted = messageAborted;
+        this.messageNotBuilt = messageNotBuilt;
+        this.messageUnstable = messageUnstable;
     }
+
+    /* notification enabled disabled setter/getter */
 
     public boolean isStartNotification() {
         return startNotification;
@@ -111,6 +131,70 @@ public class HipChatNotifier extends Notifier {
 
     public void setNotifyBackToNormal(boolean notifyBackToNormal) {
         this.notifyBackToNormal = notifyBackToNormal;
+    }
+
+    /* notification message configuration*/
+
+    public String getMessageStarted() {
+        return messageStarted;
+    }
+
+    public void setMessageStarted(String messageStarted) {
+        this.messageStarted = messageStarted;
+    }
+
+    public String getMessageBackToNormal() {
+        return messageBackToNormal;
+    }
+
+    public void setMessageBackToNormal(String messageBackToNormal) {
+        this.messageBackToNormal = messageBackToNormal;
+    }
+
+    public String getMessageSuccess() {
+        return messageSuccess;
+    }
+
+    public void setMessageSuccess(String messageSuccess) {
+        this.messageSuccess = messageSuccess;
+    }
+
+    public String getMessageFailure() {
+        return messageFailure;
+    }
+
+    public void setMessageFailure(String messageFailure) {
+        this.messageFailure = messageFailure;
+    }
+
+    public String getMessageAborted() {
+        return messageAborted;
+    }
+
+    public void setMessageAborted(String messageAborted) {
+        this.messageAborted = messageAborted;
+    }
+
+    public String getMessageNotBuilt() {
+        return messageNotBuilt;
+    }
+
+    public void setMessageNotBuilt(String messageNotBuilt) {
+        this.messageNotBuilt = messageNotBuilt;
+    }
+
+    public String getMessageUnstable() {
+        return messageUnstable;
+    }
+
+    public void setMessageUnstable(String messageUnstable) {
+        this.messageUnstable = messageUnstable;
+    }
+
+    public String getMessageDefault(String enumName) {
+        NotificationType type = NotificationType.valueOf(enumName);
+        Preconditions.checkNotNull(type, "unknown NotificationType %s", enumName);
+        return type.getDefaultTemplate();
     }
 
     public String getRoom() {
@@ -179,7 +263,7 @@ public class HipChatNotifier extends Notifier {
 
     private void publishNotificationIfEnabled(NotificationType notificationType, AbstractBuild<?, ?> build) {
         if (isNotificationEnabled(notificationType)) {
-            getHipChatService().publish(notificationType.getMessage(build), notificationType.getColor());
+            getHipChatService().publish(notificationType.getMessage(build, this), notificationType.getColor());
         }
     }
 

--- a/src/main/java/jenkins/plugins/hipchat/HipChatService.java
+++ b/src/main/java/jenkins/plugins/hipchat/HipChatService.java
@@ -28,8 +28,6 @@ public abstract class HipChatService {
         return client;
     }
 
-    public abstract void publish(NotificationType notificationType, AbstractBuild<?, ?> build);
-
     public abstract void publish(String message, String color);
 
     public abstract void publish(String message, String color, boolean notify);

--- a/src/main/java/jenkins/plugins/hipchat/NotificationTypeUtils.java
+++ b/src/main/java/jenkins/plugins/hipchat/NotificationTypeUtils.java
@@ -1,0 +1,59 @@
+package jenkins.plugins.hipchat;
+
+import com.google.common.collect.Sets;
+import hudson.model.AbstractBuild;
+import hudson.model.CauseAction;
+import hudson.scm.ChangeLogSet;
+import jenkins.model.Jenkins;
+import org.apache.commons.lang.StringUtils;
+
+import java.util.Set;
+import java.util.logging.Logger;
+
+import static java.util.logging.Level.INFO;
+
+
+public final class NotificationTypeUtils {
+    private static final Logger logger = Logger.getLogger(NotificationTypeUtils.class.getName());
+
+    private NotificationTypeUtils() {
+        /* utility method */
+    }
+
+    public static String getCause(AbstractBuild build) {
+        CauseAction cause = build.getAction(CauseAction.class);
+        if (cause != null) {
+            return cause.getShortDescription();
+        } else {
+            return null;
+        }
+    }
+
+    public static String getUrl(AbstractBuild build) {
+        return Jenkins.getInstance().getRootUrl() + build.getUrl();
+    }
+
+    public static String getChanges(AbstractBuild build) {
+        if (!build.hasChangeSetComputed()) {
+            return null;
+        }
+        Set<String> authors = Sets.newHashSet();
+        int changedFiles = 0;
+        for (Object o : build.getChangeSet().getItems()) {
+            ChangeLogSet.Entry entry = (ChangeLogSet.Entry) o;
+            authors.add(entry.getAuthor().getDisplayName());
+            try {
+                changedFiles += entry.getAffectedFiles().size();
+            } catch (UnsupportedOperationException e) {
+                logger.log(INFO, "Unable to collect the affected files for job {0}",
+                        build.getProject().getFullDisplayName());
+                return null;
+            }
+        }
+        if (changedFiles == 0) {
+            return null;
+        }
+
+        return Messages.StartWithChanges(StringUtils.join(authors, ", "), changedFiles);
+    }
+}

--- a/src/main/java/jenkins/plugins/hipchat/impl/HipChatV1Service.java
+++ b/src/main/java/jenkins/plugins/hipchat/impl/HipChatV1Service.java
@@ -28,11 +28,6 @@ public class HipChatV1Service extends HipChatService {
     }
 
     @Override
-    public void publish(NotificationType notificationType, AbstractBuild<?, ?> build) {
-        publish(notificationType.getMessage(build), notificationType.getColor());
-    }
-
-    @Override
     public void publish(String message, String color) {
         publish(message, color, shouldNotify(color));
     }

--- a/src/main/java/jenkins/plugins/hipchat/impl/HipChatV2Service.java
+++ b/src/main/java/jenkins/plugins/hipchat/impl/HipChatV2Service.java
@@ -27,10 +27,6 @@ public class HipChatV2Service extends HipChatService {
         this.roomIds = roomIds == null ? DEFAULT_ROOMS : roomIds.split("\\s*,\\s*");
     }
 
-    public void publish(NotificationType notificationType, AbstractBuild<?, ?> build) {
-        publish(notificationType.getMessage(build), notificationType.getColor());
-    }
-
     public void publish(String message, String color) {
         publish(message, color, shouldNotify(color));
     }

--- a/src/main/resources/jenkins/plugins/hipchat/HipChatNotifier/config.jelly
+++ b/src/main/resources/jenkins/plugins/hipchat/HipChatNotifier/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 
     <f:entry title="${%Auth Token}" help="/plugin/hipchat/help-projectConfig-token.html">
@@ -36,4 +37,43 @@
             <f:checkbox name="hipchat.notifyBackToNormal" checked="${instance.notifyBackToNormal}" />
         </f:entry>
     </f:section>
+
+    <f:advanced>
+        <f:section title="${%Message Templates}">
+            <f:entry title="${%Started}" help="/plugin/hipchat/help-projectConfig-hipChatMessages.html">
+                <f:textbox name="hipchat.messageStarted" value="${instance.messageStarted}"/>
+                Default: '${instance.getMessageDefault("STARTED")}'
+            </f:entry>
+
+            <f:entry title="${%Back To Normal}">
+                <f:textbox name="hipchat.messageBackToNormal" value="${instance.messageBackToNormal}"/>
+                Default: '${instance.getMessageDefault("BACK_TO_NORMAL")}'
+            </f:entry>
+
+            <f:entry title="${%Success}">
+                <f:textbox name="hipchat.messageSuccess" value="${instance.messageSuccess}"/>
+                Default: '${instance.getMessageDefault("SUCCESS")}'
+            </f:entry>
+
+            <f:entry title="${%Failure}">
+                <f:textbox name="hipchat.messageFailure" value="${instance.messageFailure}"/>
+                Default: '${instance.getMessageDefault("FAILURE")}'
+            </f:entry>
+
+            <f:entry title="${%Aborted}">
+                <f:textbox name="hipchat.messageAborted" value="${instance.messageAborted}"/>
+                Default: '${instance.getMessageDefault("ABORTED")}'
+            </f:entry>
+
+            <f:entry title="${%Not Built}">
+                <f:textbox name="hipchat.messageNotBuilt" value="${instance.messageNotBuilt}"/>
+                Default: '${instance.getMessageDefault("NOT_BUILT")}'
+            </f:entry>
+
+            <f:entry title="${%Unstable}">
+                <f:textbox name="hipchat.messageUnstable" value="${instance.messageUnstable}"/>
+                Default: '${instance.getMessageDefault("UNSTABLE")}'
+            </f:entry>
+        </f:section>
+    </f:advanced>
 </j:jelly>

--- a/src/main/resources/jenkins/plugins/hipchat/HipChatNotifier/config.jelly
+++ b/src/main/resources/jenkins/plugins/hipchat/HipChatNotifier/config.jelly
@@ -38,42 +38,15 @@
         </f:entry>
     </f:section>
 
-    <f:advanced>
-        <f:section title="${%Message Templates}">
-            <f:entry title="${%Started}" help="/plugin/hipchat/help-projectConfig-hipChatMessages.html">
-                <f:textbox name="hipchat.messageStarted" value="${instance.messageStarted}"/>
-                Default: '${instance.getMessageDefault("STARTED")}'
-            </f:entry>
+    <f:section title="${%Message Templates}">
+        <f:entry title="${%Job started}" help="/plugin/hipchat/help-projectConfig-hipChatMessages.html">
+            <f:textbox name="hipchat.startJobMessage" value="${instance.startJobMessage}"/>
+            Default: '${instance.getStartJobMessageDefault()}'
+        </f:entry>
 
-            <f:entry title="${%Back To Normal}">
-                <f:textbox name="hipchat.messageBackToNormal" value="${instance.messageBackToNormal}"/>
-                Default: '${instance.getMessageDefault("BACK_TO_NORMAL")}'
-            </f:entry>
-
-            <f:entry title="${%Success}">
-                <f:textbox name="hipchat.messageSuccess" value="${instance.messageSuccess}"/>
-                Default: '${instance.getMessageDefault("SUCCESS")}'
-            </f:entry>
-
-            <f:entry title="${%Failure}">
-                <f:textbox name="hipchat.messageFailure" value="${instance.messageFailure}"/>
-                Default: '${instance.getMessageDefault("FAILURE")}'
-            </f:entry>
-
-            <f:entry title="${%Aborted}">
-                <f:textbox name="hipchat.messageAborted" value="${instance.messageAborted}"/>
-                Default: '${instance.getMessageDefault("ABORTED")}'
-            </f:entry>
-
-            <f:entry title="${%Not Built}">
-                <f:textbox name="hipchat.messageNotBuilt" value="${instance.messageNotBuilt}"/>
-                Default: '${instance.getMessageDefault("NOT_BUILT")}'
-            </f:entry>
-
-            <f:entry title="${%Unstable}">
-                <f:textbox name="hipchat.messageUnstable" value="${instance.messageUnstable}"/>
-                Default: '${instance.getMessageDefault("UNSTABLE")}'
-            </f:entry>
-        </f:section>
-    </f:advanced>
+        <f:entry title="${%Job completed}">
+            <f:textbox name="hipchat.completeJobMessage" value="${instance.completeJobMessage}"/>
+            Default: '${instance.getCompleteJobMessageDefault()}'
+        </f:entry>
+    </f:section>
 </j:jelly>

--- a/src/main/resources/jenkins/plugins/hipchat/Messages.properties
+++ b/src/main/resources/jenkins/plugins/hipchat/Messages.properties
@@ -2,13 +2,13 @@ DisplayName=HipChat Notifications
 TestNotification=Test Notification {0}
 TestNotificationSent=Test Notification Sent
 
-MessageStart={0} - {1}
-Starting=Starting...
-BackToNormal=Back to normal after {0}
-Success=Success after {0}
-Failure=<b>FAILURE</b> after {0}
-Aborted=ABORTED after {0}
-NotBuilt=Not built
-Unstable=UNSTABLE after {0}
-Unknown=Unknown
 StartWithChanges=Started by changes from {0} ({1} file(s) changed)
+
+Started=$JOB_NAME #$BUILD_NUMBER Starting... ($CHANGES_OR_CAUSE) (<a href="$URL">Open</a>)
+BackToNormal=$JOB_NAME #$BUILD_NUMBER Back to normal after $DURATION (<a href="$URL">Open</a>)
+Success=$JOB_NAME #$BUILD_NUMBER Success after $DURATION (<a href="$URL">Open</a>)
+Failure=$JOB_NAME #$BUILD_NUMBER <b>FAILURE</b> after $DURATION (<a href="$URL">Open</a>)
+Aborted=$JOB_NAME #$BUILD_NUMBER ABORTED after $DURATION (<a href="$URL">Open</a>)
+NotBuilt=$JOB_NAME #$BUILD_NUMBER Not built after $DURATION (<a href="$URL">Open</a>)
+Unstable=$JOB_NAME #$BUILD_NUMBER UNSTABLE after $DURATION (<a href="$URL">Open</a>)
+Unknown=Unknown

--- a/src/main/resources/jenkins/plugins/hipchat/Messages.properties
+++ b/src/main/resources/jenkins/plugins/hipchat/Messages.properties
@@ -4,11 +4,15 @@ TestNotificationSent=Test Notification Sent
 
 StartWithChanges=Started by changes from {0} ({1} file(s) changed)
 
-Started=$JOB_NAME #$BUILD_NUMBER Starting... ($CHANGES_OR_CAUSE) (<a href="$URL">Open</a>)
-BackToNormal=$JOB_NAME #$BUILD_NUMBER Back to normal after $DURATION (<a href="$URL">Open</a>)
-Success=$JOB_NAME #$BUILD_NUMBER Success after $DURATION (<a href="$URL">Open</a>)
-Failure=$JOB_NAME #$BUILD_NUMBER <b>FAILURE</b> after $DURATION (<a href="$URL">Open</a>)
-Aborted=$JOB_NAME #$BUILD_NUMBER ABORTED after $DURATION (<a href="$URL">Open</a>)
-NotBuilt=$JOB_NAME #$BUILD_NUMBER Not built after $DURATION (<a href="$URL">Open</a>)
-Unstable=$JOB_NAME #$BUILD_NUMBER UNSTABLE after $DURATION (<a href="$URL">Open</a>)
+Started=Starting...
+BackToNormal=Back to normal
+Success=Success
+Failure=<b>FAILURE</b>
+Aborted=ABORTED
+NotBuilt=Not built
+Unstable=UNSTABLE
+
+JobStarted=$JOB_NAME #$BUILD_NUMBER $STATUS ($CHANGES_OR_CAUSE) (<a href="$URL">Open</a>)
+JobCompleted=$JOB_NAME #$BUILD_NUMBER $STATUS after $DURATION (<a href="$URL">Open</a>)
+
 Unknown=Unknown

--- a/src/main/webapp/help-projectConfig-hipChatMessages.html
+++ b/src/main/webapp/help-projectConfig-hipChatMessages.html
@@ -1,0 +1,19 @@
+<div>
+    <p>
+        Configures the message that will be displayed in the room. If left blank a default value will be used.
+        All normal build variables can be used with the notation <em>$VAR_NAME</em>. Additional the following
+        variables are provided:
+    </p>
+    <ul>
+        <li><strong>$DURATION</strong> - duration of the build in human readable form. Example: 13 min</li>
+        <li><strong>$URL</strong> - URL to the job page on jenkins. You can use normal HTML to create a link
+            i.e: &lt;a href="$URL"&gt;More Info&lt;a&gt; </li>
+        <li><strong>$CAUSE</strong> - cause of this change. i.e. 'starte by user foo'</li>
+        <li><strong>$CHANGES</strong> - a short overview of the changes that caused that job, if available</li>
+        <li><strong>$CHANGES_OR_CAUSE</strong> - either $CHANGES or $CAUSE, see above</li>
+        <li><strong>$STATUS</strong> - the status of the build, i.e. 'Success'</li>
+        <li><strong>$PRINT_FULL_ENV</strong> - dump of all variables, use this only for debugging purposes.
+            Be aware that it also contains the full host environment and which might contain sensitive information.
+        </li>
+    </ul>
+</div>

--- a/src/test/java/jenkins/plugins/hipchat/HipChatNotifierBuilder.java
+++ b/src/test/java/jenkins/plugins/hipchat/HipChatNotifierBuilder.java
@@ -1,0 +1,110 @@
+package jenkins.plugins.hipchat;
+
+public class HipChatNotifierBuilder {
+    private String token = "token";
+    private String room = "room";
+    private boolean startNotification = false;
+    private boolean notifySuccess = false;
+    private boolean notifyAborted = true;
+    private boolean notifyNotBuilt = false;
+    private boolean notifyUnstable = true;
+    private boolean notifyFailure = true;
+    private boolean notifyBackToNormal = true;
+    private String messageStarting;
+    private String messageBackToNormal;
+    private String messageSuccess;
+    private String messageFailure;
+    private String messageAborted;
+    private String messageNotBuilt;
+    private String messageUnstable;
+
+    public static HipChatNotifierBuilder notifier() {
+        return new HipChatNotifierBuilder();
+    }
+
+    public HipChatNotifierBuilder setToken(String token) {
+        this.token = token;
+        return this;
+    }
+
+    public HipChatNotifierBuilder setRoom(String room) {
+        this.room = room;
+        return this;
+    }
+
+    public HipChatNotifierBuilder setStartNotification(boolean startNotification) {
+        this.startNotification = startNotification;
+        return this;
+    }
+
+    public HipChatNotifierBuilder setNotifySuccess(boolean notifySuccess) {
+        this.notifySuccess = notifySuccess;
+        return this;
+    }
+
+    public HipChatNotifierBuilder setNotifyAborted(boolean notifyAborted) {
+        this.notifyAborted = notifyAborted;
+        return this;
+    }
+
+    public HipChatNotifierBuilder setNotifyNotBuilt(boolean notifyNotBuilt) {
+        this.notifyNotBuilt = notifyNotBuilt;
+        return this;
+    }
+
+    public HipChatNotifierBuilder setNotifyUnstable(boolean notifyUnstable) {
+        this.notifyUnstable = notifyUnstable;
+        return this;
+    }
+
+    public HipChatNotifierBuilder setNotifyFailure(boolean notifyFailure) {
+        this.notifyFailure = notifyFailure;
+        return this;
+    }
+
+    public HipChatNotifierBuilder setNotifyBackToNormal(boolean notifyBackToNormal) {
+        this.notifyBackToNormal = notifyBackToNormal;
+        return this;
+    }
+
+    public HipChatNotifierBuilder setMessageStarting(String messageStarting) {
+        this.messageStarting = messageStarting;
+        return this;
+    }
+
+    public HipChatNotifierBuilder setMessageBackToNormal(String messageBackToNormal) {
+        this.messageBackToNormal = messageBackToNormal;
+        return this;
+    }
+
+    public HipChatNotifierBuilder setMessageSuccess(String messageSuccess) {
+        this.messageSuccess = messageSuccess;
+        return this;
+    }
+
+    public HipChatNotifierBuilder setMessageFailure(String messageFailure) {
+        this.messageFailure = messageFailure;
+        return this;
+    }
+
+    public HipChatNotifierBuilder setMessageAborted(String messageAborted) {
+        this.messageAborted = messageAborted;
+        return this;
+    }
+
+    public HipChatNotifierBuilder setMessageNotBuilt(String messageNotBuilt) {
+        this.messageNotBuilt = messageNotBuilt;
+        return this;
+    }
+
+    public HipChatNotifierBuilder setMessageUnstable(String messageUnstable) {
+        this.messageUnstable = messageUnstable;
+        return this;
+    }
+
+    public HipChatNotifier createHipChatNotifier() {
+        return new HipChatNotifier(token, room, startNotification, notifySuccess, notifyAborted, notifyNotBuilt,
+                notifyUnstable, notifyFailure, notifyBackToNormal, messageStarting, messageBackToNormal,
+                messageSuccess, messageFailure, messageAborted, messageNotBuilt, messageUnstable);
+    }
+}

--- a/src/test/java/jenkins/plugins/hipchat/HipChatNotifierBuilder.java
+++ b/src/test/java/jenkins/plugins/hipchat/HipChatNotifierBuilder.java
@@ -10,13 +10,8 @@ public class HipChatNotifierBuilder {
     private boolean notifyUnstable = true;
     private boolean notifyFailure = true;
     private boolean notifyBackToNormal = true;
-    private String messageStarting;
-    private String messageBackToNormal;
-    private String messageSuccess;
-    private String messageFailure;
-    private String messageAborted;
-    private String messageNotBuilt;
-    private String messageUnstable;
+    private String messageJobStarted;
+    private String messageJobCompleted;
 
     public static HipChatNotifierBuilder notifier() {
         return new HipChatNotifierBuilder();
@@ -67,44 +62,18 @@ public class HipChatNotifierBuilder {
         return this;
     }
 
-    public HipChatNotifierBuilder setMessageStarting(String messageStarting) {
-        this.messageStarting = messageStarting;
-        return this;
-    }
-
-    public HipChatNotifierBuilder setMessageBackToNormal(String messageBackToNormal) {
-        this.messageBackToNormal = messageBackToNormal;
-        return this;
-    }
-
-    public HipChatNotifierBuilder setMessageSuccess(String messageSuccess) {
-        this.messageSuccess = messageSuccess;
-        return this;
-    }
-
-    public HipChatNotifierBuilder setMessageFailure(String messageFailure) {
-        this.messageFailure = messageFailure;
-        return this;
-    }
-
-    public HipChatNotifierBuilder setMessageAborted(String messageAborted) {
-        this.messageAborted = messageAborted;
-        return this;
-    }
-
-    public HipChatNotifierBuilder setMessageNotBuilt(String messageNotBuilt) {
-        this.messageNotBuilt = messageNotBuilt;
-        return this;
-    }
-
-    public HipChatNotifierBuilder setMessageUnstable(String messageUnstable) {
-        this.messageUnstable = messageUnstable;
-        return this;
-    }
-
     public HipChatNotifier createHipChatNotifier() {
         return new HipChatNotifier(token, room, startNotification, notifySuccess, notifyAborted, notifyNotBuilt,
-                notifyUnstable, notifyFailure, notifyBackToNormal, messageStarting, messageBackToNormal,
-                messageSuccess, messageFailure, messageAborted, messageNotBuilt, messageUnstable);
+                notifyUnstable, notifyFailure, notifyBackToNormal, messageJobStarted, messageJobCompleted);
+    }
+
+    public HipChatNotifierBuilder setMessageJobStarted(String messageJobStarted) {
+        this.messageJobStarted = messageJobStarted;
+        return this;
+    }
+
+    public HipChatNotifierBuilder setMessageJobCompleted(String messageJobCompleted) {
+        this.messageJobCompleted = messageJobCompleted;
+        return this;
     }
 }

--- a/src/test/java/jenkins/plugins/hipchat/NotificationTypeTest.java
+++ b/src/test/java/jenkins/plugins/hipchat/NotificationTypeTest.java
@@ -56,13 +56,11 @@ public class NotificationTypeTest {
         mockJenkins();
 
         HipChatNotifier notifier = notifier()
-                .setMessageFailure("you broke it $AUTHOR!")
+                .setMessageJobCompleted("i feel so $STATUS")
                 .createHipChatNotifier();
-        String url = "(<a href=\"http://localhost:8080/jenkins/foo/123\">Open</a>";
-        String prefix = "test-job #33";
-        assertNotifierProduces(build(), notifier, SUCCESS, prefix + " Success after 42 sec " + url + ")");
-        assertNotifierProduces(build(), notifier, FAILURE, "you broke it Mike!");
-        assertNotifierProduces(build(), notifier, NOT_BUILT, prefix + " Not built after 42 sec " + url + ")");
+        assertNotifierProduces(build(), notifier, SUCCESS, "i feel so Success");
+        assertNotifierProduces(build(), notifier, FAILURE, "i feel so <b>FAILURE</b>");
+        assertNotifierProduces(build(), notifier, NOT_BUILT, "i feel so Not built");
     }
 
     @Test
@@ -71,9 +69,8 @@ public class NotificationTypeTest {
         mockJenkins();
 
         HipChatNotifier notifier = notifier()
-                .setMessageFailure("")
-                .setMessageNotBuilt(" ")
-                .setMessageSuccess(null)
+                .setMessageJobCompleted("   ")
+                .setMessageJobStarted(null)
                 .createHipChatNotifier();
         testNormalConfiguration(build(), notifier);
     }
@@ -84,21 +81,16 @@ public class NotificationTypeTest {
         mockJenkins();
 
         HipChatNotifier notifier = notifier()
-                .setMessageStarting("MessageStarting")
-                .setMessageAborted("MessageAborted")
-                .setMessageSuccess("MessageSuccess")
-                .setMessageFailure("MessageFailure")
-                .setMessageNotBuilt("MessageNotBuilt")
-                .setMessageBackToNormal("MessageBackToNormal")
-                .setMessageUnstable("MessageUnstable")
+                .setMessageJobCompleted("completed")
+                .setMessageJobStarted("started")
                 .createHipChatNotifier();
-        assertNotifierProduces(build(), notifier, STARTED, "MessageStarting");
-        assertNotifierProduces(build(), notifier, ABORTED, "MessageAborted");
-        assertNotifierProduces(build(), notifier, SUCCESS, "MessageSuccess");
-        assertNotifierProduces(build(), notifier, FAILURE, "MessageFailure");
-        assertNotifierProduces(build(), notifier, NOT_BUILT, "MessageNotBuilt");
-        assertNotifierProduces(build(), notifier, BACK_TO_NORMAL, "MessageBackToNormal");
-        assertNotifierProduces(build(), notifier, UNSTABLE, "MessageUnstable");
+        assertNotifierProduces(build(), notifier, STARTED, "started");
+        assertNotifierProduces(build(), notifier, ABORTED, "completed");
+        assertNotifierProduces(build(), notifier, SUCCESS, "completed");
+        assertNotifierProduces(build(), notifier, FAILURE, "completed");
+        assertNotifierProduces(build(), notifier, NOT_BUILT, "completed");
+        assertNotifierProduces(build(), notifier, BACK_TO_NORMAL, "completed");
+        assertNotifierProduces(build(), notifier, UNSTABLE, "completed");
     }
 
     private void testNormalConfiguration(AbstractBuild<?, ?> build, HipChatNotifier notifier) {

--- a/src/test/java/jenkins/plugins/hipchat/NotificationTypeTest.java
+++ b/src/test/java/jenkins/plugins/hipchat/NotificationTypeTest.java
@@ -1,0 +1,217 @@
+package jenkins.plugins.hipchat;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import hudson.EnvVars;
+import hudson.model.AbstractBuild;
+import hudson.model.TaskListener;
+import hudson.model.User;
+import hudson.scm.ChangeLogSet;
+import hudson.scm.EditType;
+import jenkins.model.Jenkins;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.LinkedList;
+
+import static jenkins.plugins.hipchat.HipChatNotifierBuilder.notifier;
+import static jenkins.plugins.hipchat.NotificationType.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.mockito.Mockito.*;
+
+@RunWith(PowerMockRunner.class)
+public class NotificationTypeTest {
+    @Mock
+    Jenkins jenkins;
+
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    @PrepareForTest(Jenkins.class)
+    public void testGetMessage() throws Exception {
+        mockJenkins();
+        HipChatNotifier notifier = notifier().createHipChatNotifier();
+
+        testNormalConfiguration(build(), notifier);
+    }
+
+    @Test
+    @PrepareForTest(Jenkins.class)
+    public void testGetMessageWithConfig() throws Exception {
+        mockJenkins();
+
+        HipChatNotifier notifier = notifier()
+                .setMessageFailure("you broke it $AUTHOR!")
+                .createHipChatNotifier();
+        String url = "(<a href=\"http://localhost:8080/jenkins/foo/123\">Open</a>";
+        String prefix = "test-job #33";
+        assertNotifierProduces(build(), notifier, SUCCESS, prefix + " Success after 42 sec " + url + ")");
+        assertNotifierProduces(build(), notifier, FAILURE, "you broke it Mike!");
+        assertNotifierProduces(build(), notifier, NOT_BUILT, prefix + " Not built after 42 sec " + url + ")");
+    }
+
+    @Test
+    @PrepareForTest(Jenkins.class)
+    public void testGetMessageBlankConfiguration() throws Exception {
+        mockJenkins();
+
+        HipChatNotifier notifier = notifier()
+                .setMessageFailure("")
+                .setMessageNotBuilt(" ")
+                .setMessageSuccess(null)
+                .createHipChatNotifier();
+        testNormalConfiguration(build(), notifier);
+    }
+
+    @Test
+    @PrepareForTest(Jenkins.class)
+    public void testGetMessageAllOverride() throws Exception {
+        mockJenkins();
+
+        HipChatNotifier notifier = notifier()
+                .setMessageStarting("MessageStarting")
+                .setMessageAborted("MessageAborted")
+                .setMessageSuccess("MessageSuccess")
+                .setMessageFailure("MessageFailure")
+                .setMessageNotBuilt("MessageNotBuilt")
+                .setMessageBackToNormal("MessageBackToNormal")
+                .setMessageUnstable("MessageUnstable")
+                .createHipChatNotifier();
+        assertNotifierProduces(build(), notifier, STARTED, "MessageStarting");
+        assertNotifierProduces(build(), notifier, ABORTED, "MessageAborted");
+        assertNotifierProduces(build(), notifier, SUCCESS, "MessageSuccess");
+        assertNotifierProduces(build(), notifier, FAILURE, "MessageFailure");
+        assertNotifierProduces(build(), notifier, NOT_BUILT, "MessageNotBuilt");
+        assertNotifierProduces(build(), notifier, BACK_TO_NORMAL, "MessageBackToNormal");
+        assertNotifierProduces(build(), notifier, UNSTABLE, "MessageUnstable");
+    }
+
+    private void testNormalConfiguration(AbstractBuild<?, ?> build, HipChatNotifier notifier) {
+        String url = "(<a href=\"http://localhost:8080/jenkins/foo/123\">Open</a>";
+        String prefix = "test-job #33";
+        assertNotifierProduces(build, notifier, STARTED, prefix + " Starting... (Started by changes from john.doe@example.com (1 file(s) changed)) " + url + ")");
+        assertNotifierProduces(build, notifier, ABORTED, prefix + " ABORTED after 42 sec " + url + ")");
+        assertNotifierProduces(build, notifier, SUCCESS, prefix + " Success after 42 sec " + url + ")");
+        assertNotifierProduces(build, notifier, FAILURE, prefix + " <b>FAILURE</b> after 42 sec " + url + ")");
+        assertNotifierProduces(build, notifier, NOT_BUILT, prefix + " Not built after 42 sec " + url + ")");
+        assertNotifierProduces(build, notifier, BACK_TO_NORMAL, prefix + " Back to normal after 42 sec " + url + ")");
+        assertNotifierProduces(build, notifier, UNSTABLE, prefix + " UNSTABLE after 42 sec " + url + ")");
+    }
+
+    private AbstractBuild<?, ?> build() throws java.io.IOException, InterruptedException {
+        AbstractBuild<?, ?> build = mock(AbstractBuild.class);
+        when(build.getUrl()).thenReturn("foo/123");
+        when(build.getBuildVariables()).thenReturn(ImmutableMap.of(
+                "JOB_NAME", "test-job",
+                "BUILD_NUMBER", "33",
+                "AUTHOR", "Mike"));
+        when(build.getDurationString()).thenReturn("42 sec");
+        mockChanges(build);
+        EnvVars envVar = mock(EnvVars.class);
+        when(build.getEnvironment(any(TaskListener.class))).thenReturn(envVar);
+        return build;
+    }
+
+    private void assertNotifierProduces(AbstractBuild<?, ?> build, HipChatNotifier notifier, NotificationType type, String expected) {
+        String msg = type.getMessage(build, notifier);
+        assertThat(msg, equalTo(expected));
+    }
+
+    private void mockJenkins() {
+        PowerMockito.mockStatic(Jenkins.class);
+        PowerMockito.when(Jenkins.getInstance()).thenReturn(jenkins);
+        PowerMockito.when(jenkins.getRootUrl()).thenReturn("http://localhost:8080/jenkins/");
+    }
+
+    private void mockChanges(final AbstractBuild<?, ?> build) {
+        when(build.hasChangeSetComputed()).thenReturn(true);
+        when(build.getChangeSet()).thenAnswer(new Answer<DummyChangeSet>() {
+            @Override
+            public DummyChangeSet answer(InvocationOnMock invocationOnMock) throws Throwable {
+                return new DummyChangeSet(null);
+            }
+        });
+    }
+
+    public static class DummyChangeSet extends ChangeLogSet<DummyChangeSet.DummyChangeSetEntry> {
+        private final LinkedList<DummyChangeSetEntry> entries;
+
+        public DummyChangeSet(AbstractBuild<?, ?> build) {
+            super(build);
+            entries = Lists.newLinkedList();
+            entries.add(new DummyChangeSetEntry());
+        }
+
+        @Override
+        public boolean isEmptySet() {
+            return false;
+        }
+
+        @Override
+        public Iterator<DummyChangeSetEntry> iterator() {
+            return entries.iterator();
+        }
+
+        public static class DummyChangeSetEntry extends ChangeLogSet.Entry {
+            private final User user;
+
+            public DummyChangeSetEntry() {
+                this.user = mock(User.class);
+                when(this.user.getDisplayName()).thenReturn("john.doe@example.com");
+            }
+
+            @Override
+            public Collection<? extends AffectedFile> getAffectedFiles() {
+                return ImmutableList.of(new DummyAffectedFile("dummy-path"));
+            }
+
+            @Override
+            public String getMsg() {
+                return null;
+            }
+
+            @Override
+            public User getAuthor() {
+                return user;
+            }
+
+            @Override
+            public Collection<String> getAffectedPaths() {
+                return null;
+            }
+
+            private class DummyAffectedFile implements AffectedFile {
+                private final String path;
+
+                public DummyAffectedFile(String path) {
+                    this.path = path;
+                }
+
+                @Override
+                public String getPath() {
+                    return path;
+                }
+
+                @Override
+                public EditType getEditType() {
+                    return null;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Simpel but powerful way to customize the notification messages. For example the default 'complete' message is: 
  `$JOB_NAME #$BUILD_NUMBER $STATUS ($CHANGES_OR_CAUSE) (<a href="$BUILD_URL">Open</a>)`

All normal Jenkins and environment variables are available and allow countless combinations of configurations.  

closes jenkinsci/hipchat-plugin#25