### PR TITLE
Enable TLSv1.1/2 for HttpClient

### DIFF
--- a/src/main/java/jenkins/plugins/hipchat/HipChatService.java
+++ b/src/main/java/jenkins/plugins/hipchat/HipChatService.java
@@ -7,7 +7,6 @@ import org.apache.commons.httpclient.HttpClient;
 import org.apache.commons.httpclient.params.HttpConnectionManagerParams;
 import org.apache.commons.httpclient.protocol.Protocol;
 import org.apache.commons.httpclient.protocol.ProtocolSocketFactory;
-import org.apache.commons.httpclient.protocol.ProtocolSocketFactory;
 
 public abstract class HipChatService {
 

--- a/src/main/java/jenkins/plugins/hipchat/HipChatService.java
+++ b/src/main/java/jenkins/plugins/hipchat/HipChatService.java
@@ -4,6 +4,10 @@ import hudson.ProxyConfiguration;
 import hudson.model.AbstractBuild;
 import jenkins.model.Jenkins;
 import org.apache.commons.httpclient.HttpClient;
+import org.apache.commons.httpclient.params.HttpConnectionManagerParams;
+import org.apache.commons.httpclient.protocol.Protocol;
+import org.apache.commons.httpclient.protocol.ProtocolSocketFactory;
+import org.apache.commons.httpclient.protocol.ProtocolSocketFactory;
 
 public abstract class HipChatService {
 
@@ -11,11 +15,18 @@ public abstract class HipChatService {
      * HTTP Connection timeout when making calls to HipChat
      */
     public static final Integer DEFAULT_TIMEOUT = 10000;
+    protected static final Integer DEFAULT_PORT = 443;
+    protected static final String SCHEME = "https";
 
     protected HttpClient getHttpClient() {
+        ProtocolSocketFactory customFactory = new TLSProtocolSocketFactory();
+        Protocol customHttps = new Protocol(SCHEME, customFactory, DEFAULT_PORT);
+        Protocol.registerProtocol(SCHEME, customHttps);
+        
         HttpClient client = new HttpClient();
-        client.getHttpConnectionManager().getParams().setConnectionTimeout(DEFAULT_TIMEOUT);
-        client.getHttpConnectionManager().getParams().setSoTimeout(DEFAULT_TIMEOUT);
+        HttpConnectionManagerParams params = client.getHttpConnectionManager().getParams();
+        params.setConnectionTimeout(DEFAULT_TIMEOUT);
+        params.setSoTimeout(DEFAULT_TIMEOUT);
 
         if (Jenkins.getInstance() != null) {
             ProxyConfiguration proxy = Jenkins.getInstance().proxy;

--- a/src/main/java/jenkins/plugins/hipchat/TLSProtocolSocketFactory.java
+++ b/src/main/java/jenkins/plugins/hipchat/TLSProtocolSocketFactory.java
@@ -1,0 +1,61 @@
+package jenkins.plugins.hipchat;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.Socket;
+import java.util.ArrayList;
+import java.util.List;
+import javax.net.ssl.SSLSocket;
+import org.apache.commons.httpclient.params.HttpConnectionParams;
+import org.apache.commons.httpclient.protocol.SSLProtocolSocketFactory;
+
+/**
+ * Patterned after https://discretemkt.wordpress.com/2014/11/16/commons-httpclient-can-disable-sslv3/
+ */
+public class TLSProtocolSocketFactory extends SSLProtocolSocketFactory {
+    
+    public TLSProtocolSocketFactory() {
+        super();
+    }
+    
+    /**
+     * This is to enable TLSv1.1/2, which are disabled by default in Java 7, and disable SSLv2/3
+     * http://docs.oracle.com/javase/7/docs/technotes/guides/security/SunProviders.html
+     */
+    private Socket stripSSLv3(Socket socket) {
+        if (!(socket instanceof SSLSocket))
+            return socket;
+        SSLSocket sslSocket = (SSLSocket) socket;
+        List<String> list = new ArrayList<String>();
+        for (String s : sslSocket.getSupportedProtocols())
+            if (!s.startsWith("SSLv2") && !s.startsWith("SSLv3"))
+                list.add(s);
+        sslSocket.setEnabledProtocols(list.toArray(new String[list.size()]));
+        return sslSocket;
+    }
+    
+    @Override
+    public Socket createSocket(String host, int port) throws IOException {
+        Socket socket = super.createSocket(host, port);
+        return stripSSLv3(socket);
+    }
+    
+    @Override
+    public Socket createSocket(String host, int port, InetAddress localAddress, int localPort) throws IOException {
+        Socket socket = super.createSocket(host, port, localAddress, localPort);
+        return stripSSLv3(socket);
+    }
+    
+    @Override
+    public Socket createSocket(String host, int port, InetAddress localAddress, int localPort, HttpConnectionParams params) throws IOException {
+        Socket socket = super.createSocket(host, port, localAddress, localPort, params);
+        return stripSSLv3(socket);
+    }
+    
+    @Override
+    public Socket createSocket(Socket socket, String host, int port, boolean autoClose) throws IOException {
+        Socket newSocket = super.createSocket(socket, host, port, autoClose);
+        return stripSSLv3(newSocket);
+    }
+    
+}

--- a/src/main/java/jenkins/plugins/hipchat/TLSProtocolSocketFactory.java
+++ b/src/main/java/jenkins/plugins/hipchat/TLSProtocolSocketFactory.java
@@ -57,5 +57,4 @@ public class TLSProtocolSocketFactory extends SSLProtocolSocketFactory {
         Socket newSocket = super.createSocket(socket, host, port, autoClose);
         return stripSSLv3(newSocket);
     }
-    
 }


### PR DESCRIPTION
We just moved to a private HipChat server within my company.  They set it up with TLSv1.2 only for secure connections.  However, Java 7 does not have it enabled by default.  I found an example online on how to enable it: https://discretemkt.wordpress.com/2014/11/16/commons-httpclient-can-disable-sslv3/.  I figured other users of this plugin might also need this protocol enabled.