### PR TITLE
Adding a try catch for an NPE when collecting a change log

### DIFF
--- a/src/main/java/jenkins/plugins/hipchat/NotificationTypeUtils.java
+++ b/src/main/java/jenkins/plugins/hipchat/NotificationTypeUtils.java
@@ -39,18 +39,24 @@ public final class NotificationTypeUtils {
         }
         Set<String> authors = Sets.newHashSet();
         int changedFiles = 0;
-        for (Object o : build.getChangeSet().getItems()) {
-            ChangeLogSet.Entry entry = (ChangeLogSet.Entry) o;
-            LOGGER.log(FINEST, "Entry {0}", entry);
-            authors.add(entry.getAuthor().getDisplayName());
-            try {
-                changedFiles += entry.getAffectedFiles().size();
-            } catch (UnsupportedOperationException e) {
-                LOGGER.log(INFO, "Unable to collect the affected files for job {0}",
-                        build.getProject().getFullDisplayName());
-                return null;
+        try {
+            for (Object o : build.getChangeSet().getItems()) {
+                ChangeLogSet.Entry entry = (ChangeLogSet.Entry) o;
+                LOGGER.log(FINEST, "Entry {0}", entry);
+                authors.add(entry.getAuthor().getDisplayName());
+                try {
+                    changedFiles += entry.getAffectedFiles().size();
+                } catch (UnsupportedOperationException e) {
+                    LOGGER.log(INFO, "Unable to collect the affected files for job {0}",
+                            build.getProject().getFullDisplayName());
+                    return null;
+                }
             }
+        } catch (NullPointerException e) {
+            LOGGER.log(WARNING, "Null Pointer Exception caught while trying to compile Change Log");
+            return null;
         }
+
         if (changedFiles == 0) {
             LOGGER.log(FINE, "No changes detected");
             return null;


### PR DESCRIPTION
From time to time, when executing a build for a PR, or when merging a PR into master, the plugin cannot find the individual author's Display name triggering an NPE and failing the build. This commit surrounds the change log collection step with a try/catch for an NPE and returns a null back to the caller.

Stack trace from the issues we have seen:

```
java.lang.NullPointerException
	at jenkins.plugins.hipchat.NotificationTypeUtils.getChanges(NotificationTypeUtils.java:45)
	at jenkins.plugins.hipchat.NotificationType.collectParametersFor(NotificationType.java:122)
	at jenkins.plugins.hipchat.NotificationType.getMessage(NotificationType.java:92)
	at jenkins.plugins.hipchat.HipChatNotifier.publishNotificationIfEnabled(HipChatNotifier.java:221)
	at jenkins.plugins.hipchat.HipChatNotifier.perform(HipChatNotifier.java:204)
	at hudson.tasks.BuildStepMonitor$1.perform(BuildStepMonitor.java:20)
	at hudson.model.AbstractBuild$AbstractBuildExecution.perform(AbstractBuild.java:779)
	at hudson.model.AbstractBuild$AbstractBuildExecution.performAllBuildSteps(AbstractBuild.java:726)
	at hudson.model.Build$BuildExecution.cleanUp(Build.java:195)
	at hudson.model.Run.execute(Run.java:1788)
	at com.groupon.jenkins.dynamic.build.DynamicBuild.run(DynamicBuild.java:96)
	at hudson.model.ResourceController.execute(ResourceController.java:98)
	at hudson.model.Executor.run(Executor.java:381)
Build step 'HipChat Notifications' marked build as failure
```