### PR TITLE
Card icon support

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -45,6 +45,7 @@ To set up the plugin for an individual job, go to the job's configuration page a
   * **Text Format**: When checked, the message will be sent in text format, instead of the default HTML format. When using text format, emoticons will be properly displayed in messages, but links must be printed in full length.
   * **Notification Type**: Select which build status/result should trigger this notification.
   * **Color**: Select the color of the notification message.
+  * **Card Icon**: The icon URL to use when using card notifications.
   * **Message template**: The specific message template to use for this notification
 * **Message templates**: These templates are used as default values when the notification-specific message template is not defined.
   * **Job started**: The message to use when the build starts.
@@ -99,7 +100,7 @@ public class MyCoolCardProvider extends CardProvider {
     private static final Logger LOGGER = Logger.getLogger(MyCoolCardProvider.class.getName());
 
     @Override
-    public Card getCard(Run<?, ?> run, TaskListener taskListener, String message) {
+    public Card getCard(Run<?, ?> run, TaskListener taskListener, Icon icon, String message) {
         // implement magic
     }
 

--- a/src/main/java/jenkins/plugins/hipchat/CardProvider.java
+++ b/src/main/java/jenkins/plugins/hipchat/CardProvider.java
@@ -6,6 +6,7 @@ import hudson.model.Run;
 import hudson.model.TaskListener;
 import jenkins.plugins.hipchat.model.notifications.Attribute;
 import jenkins.plugins.hipchat.model.notifications.Card;
+import jenkins.plugins.hipchat.model.notifications.Icon;
 import jenkins.plugins.hipchat.model.notifications.Value;
 
 /**
@@ -25,10 +26,11 @@ public abstract class CardProvider extends AbstractDescribableImpl<CardProvider>
      *
      * @param run The build run.
      * @param taskListener The taskListener associated with the current build.
+     * @param icon The icon to include in the message.
      * @param message The fully resolved notification message.
      * @return The card that has been constructed for this notification. May be null if no card should be displayed.
      */
-    public abstract Card getCard(Run<?, ?> run, TaskListener taskListener, String message);
+    public abstract Card getCard(Run<?, ?> run, TaskListener taskListener, Icon icon, String message);
 
     /**
      * A simple factory method to easily create attribute for the Card. Attributes are individual information fields

--- a/src/main/java/jenkins/plugins/hipchat/HipChatNotifier.java
+++ b/src/main/java/jenkins/plugins/hipchat/HipChatNotifier.java
@@ -214,25 +214,25 @@ public class HipChatNotifier extends Notifier implements MatrixAggregatable {
         if (notifications == null) {
             notifications = new ArrayList<NotificationConfig>(7);
             if (startNotification) {
-                notifications.add(new NotificationConfig(false, false, STARTED, Color.GREEN, null));
+                notifications.add(new NotificationConfig(false, false, STARTED, Color.GREEN, null, null));
             }
             if (notifySuccess) {
-                notifications.add(new NotificationConfig(false, false, SUCCESS, Color.GREEN, null));
+                notifications.add(new NotificationConfig(false, false, SUCCESS, Color.GREEN, null, null));
             }
             if (notifyAborted) {
-                notifications.add(new NotificationConfig(true, false, ABORTED, Color.GRAY, null));
+                notifications.add(new NotificationConfig(true, false, ABORTED, Color.GRAY, null, null));
             }
             if (notifyNotBuilt) {
-                notifications.add(new NotificationConfig(true, false, NOT_BUILT, Color.GRAY, null));
+                notifications.add(new NotificationConfig(true, false, NOT_BUILT, Color.GRAY, null, null));
             }
             if (notifyUnstable) {
-                notifications.add(new NotificationConfig(true, false, UNSTABLE, Color.YELLOW, null));
+                notifications.add(new NotificationConfig(true, false, UNSTABLE, Color.YELLOW, null, null));
             }
             if (notifyFailure) {
-                notifications.add(new NotificationConfig(true, false, FAILURE, Color.RED, null));
+                notifications.add(new NotificationConfig(true, false, FAILURE, Color.RED, null, null));
             }
             if (notifyBackToNormal) {
-                notifications.add(new NotificationConfig(false, false, BACK_TO_NORMAL, Color.GREEN, null));
+                notifications.add(new NotificationConfig(false, false, BACK_TO_NORMAL, Color.GREEN, null, null));
             }
         }
         return this;

--- a/src/main/java/jenkins/plugins/hipchat/impl/DefaultCardProvider.java
+++ b/src/main/java/jenkins/plugins/hipchat/impl/DefaultCardProvider.java
@@ -31,8 +31,11 @@ public class DefaultCardProvider extends CardProvider {
     private static final Logger LOGGER = Logger.getLogger(DefaultCardProvider.class.getName());
 
     @Override
-    public Card getCard(Run<?, ?> run, TaskListener taskListener, String message) {
-        Icon icon = new Icon().withUrl("https://bit.ly/2ctIstd");
+    public Card getCard(Run<?, ?> run, TaskListener taskListener, Icon icon, String message) {
+
+        if (icon == null) {
+            icon = new Icon().withUrl("https://bit.ly/2ctIstd");
+        }
         try {
             return new Card()
                     .withStyle(Style.APPLICATION)

--- a/src/main/java/jenkins/plugins/hipchat/impl/NoopCardProvider.java
+++ b/src/main/java/jenkins/plugins/hipchat/impl/NoopCardProvider.java
@@ -7,12 +7,13 @@ import jenkins.plugins.hipchat.CardProvider;
 import jenkins.plugins.hipchat.CardProviderDescriptor;
 import jenkins.plugins.hipchat.Messages;
 import jenkins.plugins.hipchat.model.notifications.Card;
+import jenkins.plugins.hipchat.model.notifications.Icon;
 
 @Extension
 public class NoopCardProvider extends CardProvider {
 
     @Override
-    public Card getCard(Run<?, ?> run, TaskListener taskListener, String message) {
+    public Card getCard(Run<?, ?> run, TaskListener taskListener, Icon icon, String message) {
         return null;
     }
 

--- a/src/main/java/jenkins/plugins/hipchat/model/NotificationConfig.java
+++ b/src/main/java/jenkins/plugins/hipchat/model/NotificationConfig.java
@@ -13,15 +13,17 @@ public class NotificationConfig implements Describable<NotificationConfig> {
     private final boolean textFormat;
     private final NotificationType notificationType;
     private final Color color;
+    private final String icon;
     private final String messageTemplate;
 
     @DataBoundConstructor
     public NotificationConfig(boolean notifyEnabled, boolean textFormat, NotificationType notificationType, Color color,
-            String messageTemplate) {
+            String icon, String messageTemplate) {
         this.notifyEnabled = notifyEnabled;
         this.textFormat = textFormat;
         this.notificationType = notificationType;
         this.color = color;
+        this.icon = icon;
         this.messageTemplate = messageTemplate;
     }
 
@@ -41,6 +43,10 @@ public class NotificationConfig implements Describable<NotificationConfig> {
         return color;
     }
 
+    public String getIcon() {
+        return icon;
+    }
+
     public String getMessageTemplate() {
         return messageTemplate;
     }
@@ -53,7 +59,7 @@ public class NotificationConfig implements Describable<NotificationConfig> {
      * @return A new {@link NotificationConfig} instance that has its message template updated.
      */
     public NotificationConfig overrideMessageTemplate(String messageTemplate) {
-        return new NotificationConfig(notifyEnabled, textFormat, notificationType, color, messageTemplate);
+        return new NotificationConfig(notifyEnabled, textFormat, notificationType, color, icon, messageTemplate);
     }
 
     @Override
@@ -64,7 +70,7 @@ public class NotificationConfig implements Describable<NotificationConfig> {
     @Override
     public String toString() {
         return "Notification{" + "notifyEnabled=" + notifyEnabled + ", notificationType=" + notificationType
-                + ", color=" + color + ", messageTemplate=" + messageTemplate + '}';
+                + ", color=" + color + ", icon=" + icon + ", messageTemplate=" + messageTemplate + '}';
     }
 
     @Extension

--- a/src/main/java/jenkins/plugins/hipchat/workflow/HipChatSendStep.java
+++ b/src/main/java/jenkins/plugins/hipchat/workflow/HipChatSendStep.java
@@ -22,6 +22,7 @@ import jenkins.plugins.hipchat.HipChatService;
 import jenkins.plugins.hipchat.Messages;
 import jenkins.plugins.hipchat.exceptions.NotificationException;
 import jenkins.plugins.hipchat.impl.NoopCardProvider;
+import jenkins.plugins.hipchat.model.notifications.Icon;
 import jenkins.plugins.hipchat.model.notifications.Notification;
 import jenkins.plugins.hipchat.model.notifications.Notification.Color;
 import jenkins.plugins.hipchat.model.notifications.Notification.MessageFormat;
@@ -51,6 +52,9 @@ public class HipChatSendStep extends AbstractStepImpl {
 
     @DataBoundSetter
     public Color color;
+
+    @DataBoundSetter
+    public String icon;
 
     /**
      * @deprecated Use {@link #credentialId instead}.
@@ -192,7 +196,9 @@ public class HipChatSendStep extends AbstractStepImpl {
                 hipChatService.publish(new Notification()
                         .withColor(color)
                         .withMessage(message)
-                        .withCard(cardProvider.getCard(run, listener, message))
+                        .withCard(cardProvider.getCard(run, listener,
+                                (step.icon != null && !step.icon.isEmpty() ? new Icon().withUrl(step.icon) : null),
+                                message))
                         .withNotify(step.notify)
                         .withMessageFormat(step.textFormat ? MessageFormat.TEXT : MessageFormat.HTML));
                 listener.getLogger().println(Messages.NotificationSuccessful(room));

--- a/src/main/resources/jenkins/plugins/hipchat/HipChatNotifier/config.jelly
+++ b/src/main/resources/jenkins/plugins/hipchat/HipChatNotifier/config.jelly
@@ -22,7 +22,8 @@
                 <th width="5%">${%Text Format}</th>
                 <th width="15%">${%Notification Type}</th>
                 <th width="10%">${%Color}</th>
-                <th width="60%">${%Message template}</th>
+                <th width="15%">${%Card Icon}</th>
+                <th width="45%">${%Message template}</th>
                 <th width="5%"></th>
             </tr>
         </table>

--- a/src/main/resources/jenkins/plugins/hipchat/HipChatNotifier/global.jelly
+++ b/src/main/resources/jenkins/plugins/hipchat/HipChatNotifier/global.jelly
@@ -25,7 +25,8 @@
                     <th width="5%">${%Text Format}</th>
                     <th width="15%">${%Notification Type}</th>
                     <th width="10%">${%Color}</th>
-                    <th width="60%">${%Message template}</th>
+                    <th width="15%">${%Card Icon}</th>
+                    <th width="45%">${%Message template}</th>
                     <th width="5%"></th>
                 </tr>
             </table>

--- a/src/main/resources/jenkins/plugins/hipchat/HipChatNotifier/help-defaultNotifications.jelly
+++ b/src/main/resources/jenkins/plugins/hipchat/HipChatNotifier/help-defaultNotifications.jelly
@@ -8,6 +8,7 @@
         If the message template is left empty, the project's default message template will be used. If that's empty as
         well, then the plugin falls back to the default message templates.
     </p>
+    <p>The icon URL used with card provider notifications. If it's left empty, a default is provided.</p>
     <p>
         The message template may contain any normal build variable (using the <em>$VAR_NAME</em> notation).
         Additionally the following variables are provided for convenience:

--- a/src/main/resources/jenkins/plugins/hipchat/HipChatNotifier/help-notifications.jelly
+++ b/src/main/resources/jenkins/plugins/hipchat/HipChatNotifier/help-notifications.jelly
@@ -8,6 +8,7 @@
         If the message template is left empty, the project's default message template will be used. If that's empty as
         well, then the plugin falls back to the default message templates.
     </p>
+    <p>The icon URL used with card provider notifications. If it's left empty, a default is provided.</p>
     <p>
         The message template may contain any normal build variable (using the <em>$VAR_NAME</em> notation).
         Additionally the following variables are provided for convenience:

--- a/src/main/resources/jenkins/plugins/hipchat/model/NotificationConfig/config.jelly
+++ b/src/main/resources/jenkins/plugins/hipchat/model/NotificationConfig/config.jelly
@@ -16,7 +16,10 @@
                 ${it.toString()}
             </f:enum>
         </td>
-        <td style="width: 60%">
+        <td style="width: 15%">
+            <f:textbox field="icon" />
+        </td>
+        <td style="width: 45%">
             <f:textbox field="messageTemplate" />
         </td>
         <td style="width: 5%">

--- a/src/main/resources/jenkins/plugins/hipchat/workflow/HipChatSendStep/config.jelly
+++ b/src/main/resources/jenkins/plugins/hipchat/workflow/HipChatSendStep/config.jelly
@@ -4,6 +4,9 @@
     <f:entry field="message" title="${%Message}">
         <f:textbox/>
     </f:entry>
+    <f:entry field="icon" title="${%Card Icon}">
+        <f:textbox/>
+    </f:entry>
     <f:entry field="color" title="${%Color}">
         <f:enum>${it}</f:enum>
     </f:entry>

--- a/src/main/resources/jenkins/plugins/hipchat/workflow/HipChatSendStep/help-icon.html
+++ b/src/main/resources/jenkins/plugins/hipchat/workflow/HipChatSendStep/help-icon.html
@@ -1,0 +1,6 @@
+<div>
+    <b>OPTIONAL</b> Icon URL for card provider notifications.<br>
+    Any valid image URL. Should be less than 128x128 in size.<br>
+    Defaults to Jenkins logo.<br>
+    <code>hipchatSend icon: "https://bit.ly/2ctIstd", color: "YELLOW", message: "Build Started: ${env.JOB_NAME} ${env.BUILD_NUMBER}"</code>
+</div>

--- a/src/test/java/jenkins/plugins/hipchat/workflow/HipChatSendStepTest.java
+++ b/src/test/java/jenkins/plugins/hipchat/workflow/HipChatSendStepTest.java
@@ -25,6 +25,7 @@ public class HipChatSendStepTest {
                 HipChatSendStep step1 = new HipChatSendStep("message");
                 step1.color = Color.GREEN;
                 step1.room = "room";
+                step1.icon = "https://bit.ly/2ctIstd";
                 step1.v2enabled = true;
                 step1.notify = false;
 


### PR DESCRIPTION
Hello,

Here's a proposed modification to allow custom card icons to be set on each message. Right now the same icon is used for both card icon and its activity. There's also no support for the `url@2x` retina property.

Thanks.